### PR TITLE
Fixed a rounding issue when finding the timings for the current interval

### DIFF
--- a/filmstrip.js
+++ b/filmstrip.js
@@ -493,7 +493,7 @@ function createFilmstrip (stepData, interval, timings) {
             url: videoFrame.image,
             frameTime: videoFrame.time,
             hasChange: !lastVideoFrame || lastVideoFrame.time != videoFrame.time,
-            metrics: findTimings(timings, time - interval, time)
+            metrics: findTimings(timings, time, interval)
         });
         lastVideoFrame = videoFrame;
     }
@@ -524,6 +524,8 @@ function findFrame(videoFrames, time) {
     return frame;
 }
 
-function findTimings(timings, start, end) {
+function findTimings(timings, time, interval) {
+	const start = time - interval / 2;
+	const end = time + interval / 2;
     return timings.filter(timing => timing.value > start / 1000 && timing.value <= end / 1000);
 }


### PR DESCRIPTION
Finding metrics for the current interval was done by comparing the metric value with _start of the interval_ and _end of the interval_. This could lead to metrics beeing assigned to the wrong interval e.g.:
**value: 1.318**
**time: 1400**
**interval: 100**

This metric would be assigned to **1.4s**, but should be assigend to **1.3s**. By changing the rounding calculation to **[time - interval / 2, time + interval / 2]** this issue should be fixed.